### PR TITLE
Add magic link auth + user invitation

### DIFF
--- a/src/admin-app/netlify.toml
+++ b/src/admin-app/netlify.toml
@@ -1,0 +1,10 @@
+[build]
+  base = "src/admin-app"
+  command = "npm run build"
+  publish = "dist"
+  functions = "netlify/functions"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/src/admin-app/netlify/functions/invite-user.js
+++ b/src/admin-app/netlify/functions/invite-user.js
@@ -1,0 +1,59 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+export async function handler(event) {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: JSON.stringify({ error: 'Method not allowed' }) };
+  }
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    return { statusCode: 500, body: JSON.stringify({ error: 'Server misconfigured: missing Supabase credentials' }) };
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  try {
+    const { email, name, role, status, groupId, department } = JSON.parse(event.body);
+
+    if (!email || !name) {
+      return { statusCode: 400, body: JSON.stringify({ error: 'Email and name are required' }) };
+    }
+
+    // 1. Invite the user via Supabase Auth (sends invitation email)
+    const { data: authData, error: authError } = await supabase.auth.admin.inviteUserByEmail(email);
+    if (authError) {
+      return { statusCode: 400, body: JSON.stringify({ error: authError.message }) };
+    }
+
+    // 2. Insert the user row in our users table
+    const { data: userData, error: userError } = await supabase
+      .from('users')
+      .insert({
+        name,
+        email,
+        role: role || 'GeneralUser',
+        status: status || 'Active',
+        groupId: groupId || null,
+        department: department || null,
+        createdAt: new Date().toISOString().slice(0, 10),
+      })
+      .select()
+      .single();
+
+    if (userError) {
+      return { statusCode: 400, body: JSON.stringify({ error: userError.message }) };
+    }
+
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(userData),
+    };
+  } catch (err) {
+    return { statusCode: 500, body: JSON.stringify({ error: err.message }) };
+  }
+}

--- a/src/admin-app/package-lock.json
+++ b/src/admin-app/package-lock.json
@@ -61,7 +61,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -377,7 +376,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -421,7 +419,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1205,7 +1202,6 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.9.tgz",
       "integrity": "sha512-I8yO3t4T0y7bvDiR1qhIN6iBWZOTBfVOnmLlM7K6h3dx5YX2a7rnkuXzc2UkZaqhxY9NgTnEbdPlokR1RxCNRQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "@mui/core-downloads-tracker": "^7.3.9",
@@ -2047,7 +2043,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2113,7 +2108,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2237,7 +2231,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2658,7 +2651,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3508,7 +3500,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3587,7 +3578,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3597,7 +3587,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3641,15 +3630,13 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
       "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -3780,8 +3767,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -4112,7 +4098,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4255,7 +4240,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/admin-app/src/App.jsx
+++ b/src/admin-app/src/App.jsx
@@ -3,6 +3,7 @@ import { ROLES } from './data/api';
 import AdminLayout from './components/layout/AdminLayout';
 import RequireAuth from './features/auth/RequireAuth';
 import LoginPage from './features/auth/LoginPage';
+import AuthCallback from './features/auth/AuthCallback';
 import DashboardPage from './features/dashboard/DashboardPage';
 import ChallengesPage from './features/challenges/ChallengesPage';
 import ChallengeForm from './features/challenges/ChallengeForm';
@@ -22,6 +23,7 @@ export default function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/login" element={<LoginPage />} />
+        <Route path="/auth/callback" element={<AuthCallback />} />
 
         <Route
           element={

--- a/src/admin-app/src/data/api.js
+++ b/src/admin-app/src/data/api.js
@@ -57,7 +57,14 @@ export async function getUserById(id) {
 }
 
 export async function createUser(data) {
-  return unwrap(await supabase.from('users').insert(data).select().single());
+  const res = await fetch('/.netlify/functions/invite-user', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  const result = await res.json();
+  if (!res.ok) throw new Error(result.error || 'Failed to invite user');
+  return result;
 }
 
 export async function updateUser(id, data) {

--- a/src/admin-app/src/features/auth/AuthCallback.jsx
+++ b/src/admin-app/src/features/auth/AuthCallback.jsx
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Box, CircularProgress, Typography } from '@mui/material';
+import { supabase } from '../../data/supabase';
+
+export default function AuthCallback() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    // Supabase automatically picks up the tokens from the URL hash/query params
+    // and fires onAuthStateChange in AuthContext. We just need to wait a moment
+    // for the session to be established, then redirect.
+    const handleCallback = async () => {
+      const { error } = await supabase.auth.getSession();
+      if (error) {
+        console.error('Auth callback error:', error.message);
+        navigate('/login');
+      } else {
+        navigate('/');
+      }
+    };
+
+    handleCallback();
+  }, [navigate]);
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', minHeight: '100vh', gap: 2 }}>
+      <CircularProgress />
+      <Typography color="text.secondary">Signing you in...</Typography>
+    </Box>
+  );
+}

--- a/src/admin-app/src/features/auth/AuthContext.jsx
+++ b/src/admin-app/src/features/auth/AuthContext.jsx
@@ -25,6 +25,13 @@ export function AuthProvider({ children }) {
       if (session?.user?.email) {
         const appUser = await loadAppUser(session.user.email);
         setUser(appUser);
+      } else {
+        // Restore dev login session if present
+        const devEmail = localStorage.getItem('gsc_dev_user');
+        if (devEmail) {
+          const appUser = await loadAppUser(devEmail);
+          if (appUser) setUser(appUser);
+        }
       }
       setLoading(false);
     });
@@ -55,9 +62,19 @@ export function AuthProvider({ children }) {
     return { success: true };
   };
 
+  // Dev-only: bypass Supabase Auth and load user directly from DB
+  const devLogin = async (email) => {
+    const appUser = await loadAppUser(email);
+    if (!appUser) return { success: false, error: 'User not found in database' };
+    setUser(appUser);
+    localStorage.setItem('gsc_dev_user', email);
+    return { success: true };
+  };
+
   const logout = async () => {
     await supabase.auth.signOut();
     setUser(null);
+    localStorage.removeItem('gsc_dev_user');
   };
 
   const hasRole = (requiredRole) => {
@@ -67,7 +84,7 @@ export function AuthProvider({ children }) {
   };
 
   const value = useMemo(
-    () => ({ user, loading, login, logout, hasRole }),
+    () => ({ user, loading, login, devLogin, logout, hasRole }),
     [user, loading],
   );
 

--- a/src/admin-app/src/features/auth/AuthContext.jsx
+++ b/src/admin-app/src/features/auth/AuthContext.jsx
@@ -1,35 +1,63 @@
-import { createContext, useContext, useState, useMemo } from 'react';
+import { createContext, useContext, useState, useEffect, useMemo } from 'react';
+import { supabase } from '../../data/supabase';
 import { ROLES } from '../../data/api';
 
 const AuthContext = createContext(null);
 
-const MOCK_ACCOUNTS = [
-  { email: 'kristin.mroz@mpca.mn.gov', password: 'admin', id: 1, name: 'Kristin Mroz-Risse', role: ROLES.SUPER_ADMIN },
-  { email: 'sarah.johnson@mpca.mn.gov', password: 'user', id: 5, name: 'Sarah Johnson', role: ROLES.GENERAL_USER },
-];
-
 export function AuthProvider({ children }) {
-  const [user, setUser] = useState(() => {
-    try {
-      const stored = localStorage.getItem('gsc_auth_user');
-      return stored ? JSON.parse(stored) : null;
-    } catch { return null; }
-  });
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
 
-  const login = (email, password) => {
-    const account = MOCK_ACCOUNTS.find(
-      (a) => a.email === email && a.password === password,
+  // Look up the app user row by email to get role, name, etc.
+  async function loadAppUser(email) {
+    const { data, error } = await supabase
+      .from('users')
+      .select('*')
+      .eq('email', email)
+      .single();
+    if (error || !data) return null;
+    return data;
+  }
+
+  useEffect(() => {
+    // Restore session on mount
+    supabase.auth.getSession().then(async ({ data: { session } }) => {
+      if (session?.user?.email) {
+        const appUser = await loadAppUser(session.user.email);
+        setUser(appUser);
+      }
+      setLoading(false);
+    });
+
+    // Listen for auth changes (login, logout, token refresh)
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(
+      async (event, session) => {
+        if (event === 'SIGNED_IN' && session?.user?.email) {
+          const appUser = await loadAppUser(session.user.email);
+          setUser(appUser);
+        } else if (event === 'SIGNED_OUT') {
+          setUser(null);
+        }
+      },
     );
-    if (!account) return { success: false, error: 'Invalid email or password' };
-    const { password: _pw, ...safeUser } = account;
-    setUser(safeUser);
-    localStorage.setItem('gsc_auth_user', JSON.stringify(safeUser));
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  const login = async (email) => {
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: {
+        emailRedirectTo: `${window.location.origin}/auth/callback`,
+      },
+    });
+    if (error) return { success: false, error: error.message };
     return { success: true };
   };
 
-  const logout = () => {
+  const logout = async () => {
+    await supabase.auth.signOut();
     setUser(null);
-    localStorage.removeItem('gsc_auth_user');
   };
 
   const hasRole = (requiredRole) => {
@@ -39,8 +67,8 @@ export function AuthProvider({ children }) {
   };
 
   const value = useMemo(
-    () => ({ user, login, logout, hasRole }),
-    [user],
+    () => ({ user, loading, login, logout, hasRole }),
+    [user, loading],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/admin-app/src/features/auth/LoginPage.jsx
+++ b/src/admin-app/src/features/auth/LoginPage.jsx
@@ -1,34 +1,27 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import {
   Box, Card, CardContent, TextField, Button, Typography, Alert, Stack,
 } from '@mui/material';
-import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import { useAuth } from './AuthContext';
-import { resetDemoData } from '../../data/api';
 
 export default function LoginPage() {
   const { login } = useAuth();
-  const navigate = useNavigate();
   const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
+  const [sent, setSent] = useState(false);
   const [error, setError] = useState('');
-  const [resetMsg, setResetMsg] = useState('');
+  const [submitting, setSubmitting] = useState(false);
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    const result = login(email, password);
+    setError('');
+    setSubmitting(true);
+    const result = await login(email);
+    setSubmitting(false);
     if (result.success) {
-      navigate('/');
+      setSent(true);
     } else {
       setError(result.error);
     }
-  };
-
-  const handleReset = () => {
-    resetDemoData();
-    setResetMsg('Demo data has been reset to defaults.');
-    setTimeout(() => setResetMsg(''), 3000);
   };
 
   return (
@@ -48,60 +41,39 @@ export default function LoginPage() {
             GreenStep Admin
           </Typography>
           <Typography variant="body2" color="text.secondary" textAlign="center" mb={3}>
-            Sign in to the admin console
+            Sign in with your email
           </Typography>
 
           {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
-          {resetMsg && <Alert severity="success" sx={{ mb: 2 }}>{resetMsg}</Alert>}
 
-          <form onSubmit={handleSubmit}>
-            <Stack spacing={2}>
-              <TextField
-                label="Email"
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-                fullWidth
-              />
-              <TextField
-                label="Password"
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-                fullWidth
-              />
-              <Button type="submit" variant="contained" size="large" fullWidth>
-                Sign In
-              </Button>
-            </Stack>
-          </form>
-
-          <Box sx={{ mt: 3 }}>
-            <Button
-              variant="outlined"
-              size="small"
-              fullWidth
-              onClick={() => {
-                const result = login('kristin.mroz@mpca.mn.gov', 'admin');
-                if (result.success) navigate('/');
-              }}
-            >
-              Quick Login as Kristin (SuperAdmin)
-            </Button>
-          </Box>
-
-          <Box sx={{ textAlign: 'center', mt: 2 }}>
-            <Button
-              size="small"
-              color="warning"
-              startIcon={<RestartAltIcon />}
-              onClick={handleReset}
-            >
-              Reset Demo Data
-            </Button>
-          </Box>
+          {sent ? (
+            <Alert severity="success">
+              Check your email for a magic link to sign in. You can close this tab.
+            </Alert>
+          ) : (
+            <form onSubmit={handleSubmit}>
+              <Stack spacing={2}>
+                <TextField
+                  label="Email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                  fullWidth
+                  autoFocus
+                />
+                <Button
+                  type="submit"
+                  variant="contained"
+                  size="large"
+                  fullWidth
+                  disabled={submitting}
+                >
+                  {submitting ? 'Sending...' : 'Send Magic Link'}
+                </Button>
+              </Stack>
+            </form>
+          )}
         </CardContent>
       </Card>
     </Box>

--- a/src/admin-app/src/features/auth/LoginPage.jsx
+++ b/src/admin-app/src/features/auth/LoginPage.jsx
@@ -1,11 +1,13 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   Box, Card, CardContent, TextField, Button, Typography, Alert, Stack,
 } from '@mui/material';
 import { useAuth } from './AuthContext';
 
 export default function LoginPage() {
-  const { login } = useAuth();
+  const { login, devLogin } = useAuth();
+  const navigate = useNavigate();
   const [email, setEmail] = useState('');
   const [sent, setSent] = useState(false);
   const [error, setError] = useState('');
@@ -74,6 +76,20 @@ export default function LoginPage() {
               </Stack>
             </form>
           )}
+
+          <Box sx={{ mt: 3 }}>
+            <Button
+              variant="outlined"
+              size="small"
+              fullWidth
+              onClick={async () => {
+                const result = await devLogin('kristin.mroz@mpca.mn.gov');
+                if (result.success) navigate('/');
+              }}
+            >
+              Quick Login as Kristin (SuperAdmin)
+            </Button>
+          </Box>
         </CardContent>
       </Card>
     </Box>

--- a/src/admin-app/src/features/auth/RequireAuth.jsx
+++ b/src/admin-app/src/features/auth/RequireAuth.jsx
@@ -1,9 +1,18 @@
 import { Navigate, useLocation } from 'react-router-dom';
+import { Box, CircularProgress } from '@mui/material';
 import { useAuth } from './AuthContext';
 
 export default function RequireAuth({ children, minRole }) {
-  const { user, hasRole } = useAuth();
+  const { user, loading, hasRole } = useAuth();
   const location = useLocation();
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh' }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
 
   if (!user) return <Navigate to="/login" state={{ from: location }} replace />;
   if (minRole && !hasRole(minRole)) return <Navigate to="/" replace />;


### PR DESCRIPTION
Replace mock authentication with Supabase Auth magic links. Users sign in via email link instead of password. SuperAdmins can invite new users, who receive an email invitation via a Netlify serverless function. Includes dev quick login bypass for testing.