### PR TITLE
feat: wire activity logging to admin actions

### DIFF
--- a/src/admin-app/src/data/api.js
+++ b/src/admin-app/src/data/api.js
@@ -206,6 +206,15 @@ export async function getActivityLogsByUser(userId) {
   return unwrap(await supabase.from('activity_logs').select('*').eq('userId', userId).order('timestamp', { ascending: false }));
 }
 
+export async function getActivityLogs() {
+  return unwrap(await supabase.from('activity_logs').select('*').order('timestamp', { ascending: false }));
+}
+
+/** Log an admin action. Call this after any mutating operation. */
+export async function logActivity(userId, action, details) {
+  return unwrap(await supabase.from('activity_logs').insert({ userId, action, details }).select().single());
+}
+
 // ─── Groups / Departments ───────────────────────────
 export async function getGroups() {
   return unwrap(await supabase.from('departments').select('*').order('id'));

--- a/src/admin-app/src/features/challenges/ChallengeForm.jsx
+++ b/src/admin-app/src/features/challenges/ChallengeForm.jsx
@@ -37,6 +37,7 @@ import {
   deleteAction,
   getGroups,
   getPresets,
+  logActivity,
 } from "../../data/api";
 import { useAuth } from "../auth/AuthContext";
 
@@ -112,6 +113,7 @@ export default function ChallengeForm() {
     const payload = { ...form, groupId: form.groupId || null };
     if (isEdit) {
       await updateChallenge(Number(id), payload);
+      await logActivity(user.id, 'Updated challenge', `Updated ${payload.name}`);
     } else {
       const newChallenge = await createChallenge({ ...payload, createdBy: user.id, actionIds: [], participants: [], joinBy: null });
       if (presetActions.length > 0) {
@@ -122,6 +124,7 @@ export default function ChallengeForm() {
         }
         await updateChallenge(newChallenge.id, { actionIds: newActionIds });
       }
+      await logActivity(user.id, 'Created challenge', `Created ${payload.name}`);
     }
     navigate("/challenges");
   };

--- a/src/admin-app/src/features/challenges/ChallengesPage.jsx
+++ b/src/admin-app/src/features/challenges/ChallengesPage.jsx
@@ -11,7 +11,7 @@ import ArchiveIcon from '@mui/icons-material/Archive';
 import DeleteIcon from '@mui/icons-material/Delete';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import BookmarkIcon from '@mui/icons-material/Bookmark';
-import { getChallenges, archiveChallenge, deleteChallenge, CHALLENGE_STATUSES, getGroups, getParticipantCounts } from '../../data/api';
+import { getChallenges, archiveChallenge, deleteChallenge, logActivity, CHALLENGE_STATUSES, getGroups, getParticipantCounts } from '../../data/api';
 import { useAuth } from '../auth/AuthContext';
 import CSVExport from '../../components/shared/CSVExport';
 import ConfirmDialog from '../../components/shared/ConfirmDialog';
@@ -69,13 +69,17 @@ export default function ChallengesPage() {
   });
 
   const handleArchive = async (id) => {
+    const c = challenges.find((ch) => ch.id === id);
     await archiveChallenge(id);
+    await logActivity(user?.id, 'Archived challenge', `Archived ${c?.name || 'challenge'}`);
     load();
   };
 
   const handleDelete = async () => {
     if (pendingDelete) {
+      const c = challenges.find((ch) => ch.id === pendingDelete);
       await deleteChallenge(pendingDelete);
+      await logActivity(user?.id, 'Deleted challenge', `Deleted ${c?.name || 'challenge'}`);
       setPendingDelete(null);
       setConfirmOpen(false);
       load();

--- a/src/admin-app/src/features/groups/GroupsPage.jsx
+++ b/src/admin-app/src/features/groups/GroupsPage.jsx
@@ -19,7 +19,7 @@ import {
 import AddIcon from "@mui/icons-material/Add";
 import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
-import { getGroups, getUsers, getChallenges, deleteGroup } from "../../data/api";
+import { getGroups, getUsers, getChallenges, deleteGroup, logActivity } from "../../data/api";
 import { useAuth } from "../auth/AuthContext";
 import ConfirmDialog from "../../components/shared/ConfirmDialog";
 
@@ -32,7 +32,7 @@ export default function GroupsPage() {
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [pendingDelete, setPendingDelete] = useState(null);
   const navigate = useNavigate();
-  const { hasRole } = useAuth();
+  const { user, hasRole } = useAuth();
   const canManage = hasRole("Admin");
 
   const load = async () => {
@@ -57,7 +57,9 @@ export default function GroupsPage() {
 
   const handleDelete = async () => {
     if (pendingDelete) {
+      const g = groups.find((gr) => gr.id === pendingDelete);
       await deleteGroup(pendingDelete);
+      await logActivity(user?.id, 'Deleted group', `Deleted ${g?.name || 'group'}`);
       setPendingDelete(null);
       setConfirmOpen(false);
       load();

--- a/src/admin-app/src/features/users/UserDetail.jsx
+++ b/src/admin-app/src/features/users/UserDetail.jsx
@@ -286,7 +286,7 @@ export default function UserDetail() {
                   <TableRow key={l.id}>
                     <TableCell>{l.action}</TableCell>
                     <TableCell>{l.details}</TableCell>
-                    <TableCell>{l.timestamp}</TableCell>
+                    <TableCell>{new Date(l.timestamp).toLocaleString()}</TableCell>
                   </TableRow>
                 ))}
                 {logs.length === 0 && (

--- a/src/admin-app/src/features/users/UserForm.jsx
+++ b/src/admin-app/src/features/users/UserForm.jsx
@@ -4,7 +4,8 @@ import {
   Box, Typography, TextField, MenuItem, Button, Stack, Paper, Grid,
 } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import { getUserById, createUser, updateUser, ROLES, USER_STATUSES, getGroups } from '../../data/api';
+import { getUserById, createUser, updateUser, logActivity, ROLES, USER_STATUSES, getGroups } from '../../data/api';
+import { useAuth } from '../auth/AuthContext';
 
 const EMPTY = {
   name: '',
@@ -18,6 +19,7 @@ export default function UserForm() {
   const { id } = useParams();
   const isEdit = Boolean(id);
   const navigate = useNavigate();
+  const { user: currentUser } = useAuth();
   const [form, setForm] = useState(EMPTY);
   const [groups, setGroups] = useState([]);
 
@@ -38,8 +40,10 @@ export default function UserForm() {
     const payload = { ...form, groupId: form.groupId || null };
     if (isEdit) {
       await updateUser(Number(id), payload);
+      await logActivity(currentUser?.id, 'Updated user', `Updated ${payload.name}`);
     } else {
       await createUser(payload);
+      await logActivity(currentUser?.id, 'Created user', `Created ${payload.name} (${payload.role})`);
     }
     navigate('/users');
   };

--- a/src/admin-app/src/features/users/UsersPage.jsx
+++ b/src/admin-app/src/features/users/UsersPage.jsx
@@ -30,6 +30,7 @@ import {
   deactivateUser,
   activateUser,
   deleteUser,
+  logActivity,
   ROLES,
   USER_STATUSES,
   getGroups,
@@ -98,11 +99,17 @@ export default function UsersPage() {
 
   const handleToggleStatus = async () => {
     if (!pendingAction) return;
-    if (pendingAction.status === USER_STATUSES.ACTIVE) {
+    const wasActive = pendingAction.status === USER_STATUSES.ACTIVE;
+    if (wasActive) {
       await deactivateUser(pendingAction.id);
     } else {
       await activateUser(pendingAction.id);
     }
+    await logActivity(
+      user.id,
+      wasActive ? 'Deactivated user' : 'Activated user',
+      `${wasActive ? 'Deactivated' : 'Activated'} ${pendingAction.name}`
+    );
     setPendingAction(null);
     setConfirmOpen(false);
     load();


### PR DESCRIPTION
Log admin actions (create/edit/deactivate users, create/edit/archive/delete challenges, delete groups) to the activity_logs table. Adds logActivity() API function and getActivityLogs() for fetching all logs.