### PR TITLE
fix: move Supabase credentials to environment variables

### DIFF
--- a/src/admin-app/.env.example
+++ b/src/admin-app/.env.example
@@ -1,2 +1,3 @@
-# API base URL (used when backend is connected)
-# VITE_API_BASE_URL=http://localhost:8000/api
+# Supabase connection (required)
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key-here

--- a/src/admin-app/src/data/supabase.js
+++ b/src/admin-app/src/data/supabase.js
@@ -1,6 +1,10 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || 'https://kyburiaubfmbnxbryeqq.supabase.co';
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imt5YnVyaWF1YmZtYm54YnJ5ZXFxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzMxNTA3NDksImV4cCI6MjA4ODcyNjc0OX0.um0jAXms2FyGvkYwon20ujPT5YCRMGhdsHIUA83SWsk';
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY environment variables');
+}
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
Remove hardcoded Supabase URL and anon key from source code. App now requires VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY env vars. Updated .env.example accordingly. Closes #6