### PR TITLE
chore: gitignore .env files in admin-app

### DIFF
--- a/src/admin-app/.gitignore
+++ b/src/admin-app/.gitignore
@@ -12,6 +12,11 @@ dist
 dist-ssr
 *.local
 
+# Environment variables
+.env
+.env.*
+!.env.example
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json


### PR DESCRIPTION
Prevents people from accidentally committing local Supabase credentials. Keeps `.env.example` tracked as the template.