### PR TITLE
fix: exchange PKCE code for session in auth callback

### DIFF
--- a/src/admin-app/src/features/auth/AuthCallback.jsx
+++ b/src/admin-app/src/features/auth/AuthCallback.jsx
@@ -19,17 +19,32 @@ export default function AuthCallback() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    // Supabase automatically picks up the tokens from the URL hash/query params
-    // and fires onAuthStateChange in AuthContext. We just need to wait a moment
-    // for the session to be established, then redirect.
+    // supabase-js v2 defaults to PKCE flow, so the magic-link redirect lands
+    // here with a `?code=...` query param that needs to be swapped for a
+    // session before we navigate. getSession() alone won't do that exchange.
     const handleCallback = async () => {
-      const { error } = await supabase.auth.getSession();
-      if (error) {
-        console.error("Auth callback error:", error.message);
-        navigate("/login");
+      const params = new URLSearchParams(window.location.search);
+      const code = params.get("code");
+
+      if (code) {
+        const { error } = await supabase.auth.exchangeCodeForSession(code);
+        if (error) {
+          console.error("Auth callback exchange error:", error.message);
+          navigate("/login");
+          return;
+        }
       } else {
-        navigate("/");
+        // Implicit / hash-token flow: detectSessionInUrl picks tokens up
+        // automatically; just verify a session ended up established.
+        const { data, error } = await supabase.auth.getSession();
+        if (error || !data.session) {
+          if (error) console.error("Auth callback error:", error.message);
+          navigate("/login");
+          return;
+        }
       }
+
+      navigate("/");
     };
 
     handleCallback();


### PR DESCRIPTION
Magic-link sign-ins were silently bouncing the user back to /login. supabase-js v2 defaults to PKCE flow, which sends a ?code= query param that has to be explicitly exchanged for a session. AuthCallback was only calling getSession(), which returned null because the exchange hadn't happened yet, so the user was redirected to / with no session and immediately punted back to /login by RequireAuth. This adds the exchangeCodeForSession() call.