### PR TITLE
feat: switch from magic-link clicks to 6-digit OTP code auth

### DIFF
--- a/src/admin-app/src/features/auth/AuthContext.jsx
+++ b/src/admin-app/src/features/auth/AuthContext.jsx
@@ -5,7 +5,7 @@
  * Wraps the app in `<AuthProvider>` to:
  *   - Restore Supabase sessions on mount (and a "dev login" fallback from localStorage).
  *   - Subscribe to Supabase auth events so login/logout in another tab still propagates.
- *   - Expose `login`, `devLogin`, `logout`, and `hasRole` to consumers.
+ *   - Expose `login`, `verifyCode`, `devLogin`, `logout`, and `hasRole` to consumers.
  *
  * The hook (`useAuth`) and the context object live in sibling files so this
  * module exports only a component — required for Vite React Fast Refresh.
@@ -108,11 +108,27 @@ export function AuthProvider({ children }) {
     return () => subscription.unsubscribe();
   }, []);
 
-  /** Send a magic-link email to start a real Supabase Auth session. */
+  /**
+   * Step 1 of email auth: send the user a 6-digit code by email.
+   * Step 2 (`verifyCode`) is what actually starts the Supabase Auth session.
+   *
+   * Code-based instead of click-based because institutional email scanners
+   * (Microsoft Defender Safe Links, Mimecast, etc.) pre-fetch one-time
+   * magic-link URLs on arrival and consume the token before the user can
+   * click. A 6-digit code in plain text dodges that whole class of issue.
+   */
   const login = useCallback(async (email) => {
-    const { error } = await supabase.auth.signInWithOtp({
+    const { error } = await supabase.auth.signInWithOtp({ email });
+    if (error) return { success: false, error: error.message };
+    return { success: true };
+  }, []);
+
+  /** Step 2 of email auth: verify the 6-digit code the user typed in. */
+  const verifyCode = useCallback(async (email, code) => {
+    const { error } = await supabase.auth.verifyOtp({
       email,
-      options: { emailRedirectTo: `${window.location.origin}/auth/callback` },
+      token: code,
+      type: "email",
     });
     if (error) return { success: false, error: error.message };
     return { success: true };
@@ -146,8 +162,8 @@ export function AuthProvider({ children }) {
   );
 
   const value = useMemo(
-    () => ({ user, loading, login, devLogin, logout, hasRole }),
-    [user, loading, login, devLogin, logout, hasRole],
+    () => ({ user, loading, login, verifyCode, devLogin, logout, hasRole }),
+    [user, loading, login, verifyCode, devLogin, logout, hasRole],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/admin-app/src/features/auth/AuthContext.jsx
+++ b/src/admin-app/src/features/auth/AuthContext.jsx
@@ -123,7 +123,16 @@ export function AuthProvider({ children }) {
     return { success: true };
   }, []);
 
-  /** Step 2 of email auth: verify the 8-digit code the user typed in. */
+  /**
+   * Step 2 of email auth: verify the 8-digit code the user typed in.
+   *
+   * After verifyOtp succeeds the Supabase client has the session, but
+   * the SIGNED_IN event that triggers loadAppUser fires asynchronously.
+   * If the caller navigates immediately, RequireAuth sees `user` still
+   * null and bounces back to /login. We avoid that race by loading the
+   * app user inline here and setting state before returning, so an
+   * `await verifyCode(...)` truly blocks until the caller is signed in.
+   */
   const verifyCode = useCallback(async (email, code) => {
     const { error } = await supabase.auth.verifyOtp({
       email,
@@ -131,6 +140,20 @@ export function AuthProvider({ children }) {
       type: "email",
     });
     if (error) return { success: false, error: error.message };
+
+    const appUser = await loadAppUser(email);
+    if (!appUser) {
+      // Supabase auth accepted the code but this email has no row in
+      // public.users -- they're not an admin. Drop the session and
+      // surface a clear error.
+      await supabase.auth.signOut();
+      return {
+        success: false,
+        error: "No admin account exists for this email. Contact an administrator to be invited.",
+      };
+    }
+    setUser(appUser);
+    setAuthEmail(email);
     return { success: true };
   }, []);
 

--- a/src/admin-app/src/features/auth/AuthContext.jsx
+++ b/src/admin-app/src/features/auth/AuthContext.jsx
@@ -109,13 +109,13 @@ export function AuthProvider({ children }) {
   }, []);
 
   /**
-   * Step 1 of email auth: send the user a 6-digit code by email.
+   * Step 1 of email auth: send the user a 8-digit code by email.
    * Step 2 (`verifyCode`) is what actually starts the Supabase Auth session.
    *
    * Code-based instead of click-based because institutional email scanners
    * (Microsoft Defender Safe Links, Mimecast, etc.) pre-fetch one-time
    * magic-link URLs on arrival and consume the token before the user can
-   * click. A 6-digit code in plain text dodges that whole class of issue.
+   * click. A 8-digit code in plain text dodges that whole class of issue.
    */
   const login = useCallback(async (email) => {
     const { error } = await supabase.auth.signInWithOtp({ email });
@@ -123,7 +123,7 @@ export function AuthProvider({ children }) {
     return { success: true };
   }, []);
 
-  /** Step 2 of email auth: verify the 6-digit code the user typed in. */
+  /** Step 2 of email auth: verify the 8-digit code the user typed in. */
   const verifyCode = useCallback(async (email, code) => {
     const { error } = await supabase.auth.verifyOtp({
       email,

--- a/src/admin-app/src/features/auth/LoginPage.jsx
+++ b/src/admin-app/src/features/auth/LoginPage.jsx
@@ -1,11 +1,17 @@
 /**
  * @file LoginPage.jsx
- * @summary Sign-in screen with magic-link + dev-login fallback.
+ * @summary Sign-in screen with two-step OTP code auth + a dev-login fallback.
  *
- * The "real" login flow uses Supabase magic links (email OTP). The
- * "Dev Login" button bypasses Supabase Auth and looks the user up by
- * email directly -- intended for local development and team demos
- * before the production Auth flow is fully provisioned.
+ * Step 1: user enters their email and we send them a 6-digit code via Supabase
+ * Auth. Step 2: user enters the code and we exchange it for a session.
+ *
+ * Code entry instead of magic-link clicks because institutional email scanners
+ * (Microsoft Defender Safe Links, Mimecast, etc.) pre-fetch one-time link URLs
+ * on arrival and consume the token before the user can click. A code in plain
+ * text dodges that whole class of issue.
+ *
+ * The "Quick Login as Kristin" button bypasses Supabase Auth entirely and is
+ * intended for local development and team demos only.
  */
 
 import { useState } from "react";
@@ -17,24 +23,44 @@ import { Box, Card, CardContent, TextField, Button, Typography, Alert, Stack } f
 import { useAuth } from "./useAuth";
 
 export default function LoginPage() {
-  const { login, devLogin } = useAuth();
+  const { login, verifyCode, devLogin } = useAuth();
   const navigate = useNavigate();
+  const [step, setStep] = useState("email"); // "email" | "code"
   const [email, setEmail] = useState("");
-  const [sent, setSent] = useState(false);
+  const [code, setCode] = useState("");
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
-  const handleSubmit = async (e) => {
+  const handleSendCode = async (e) => {
     e.preventDefault();
     setError("");
     setSubmitting(true);
     const result = await login(email);
     setSubmitting(false);
     if (result.success) {
-      setSent(true);
+      setStep("code");
     } else {
       setError(result.error);
     }
+  };
+
+  const handleVerifyCode = async (e) => {
+    e.preventDefault();
+    setError("");
+    setSubmitting(true);
+    const result = await verifyCode(email, code.trim());
+    setSubmitting(false);
+    if (result.success) {
+      navigate("/");
+    } else {
+      setError(result.error);
+    }
+  };
+
+  const handleStartOver = () => {
+    setStep("email");
+    setCode("");
+    setError("");
   };
 
   return (
@@ -54,7 +80,9 @@ export default function LoginPage() {
             GreenStep Admin
           </Typography>
           <Typography variant="body2" color="text.secondary" textAlign="center" mb={3}>
-            Sign in with your email
+            {step === "email"
+              ? "Sign in with your email"
+              : `Enter the 6-digit code we sent to ${email}`}
           </Typography>
 
           {error && (
@@ -63,13 +91,8 @@ export default function LoginPage() {
             </Alert>
           )}
 
-          {sent ? (
-            <Alert severity="success">
-              Check your email for a magic link to sign in. If you don't see it, check your
-              junk/spam folder. You can close this tab.
-            </Alert>
-          ) : (
-            <form onSubmit={handleSubmit}>
+          {step === "email" ? (
+            <form onSubmit={handleSendCode}>
               <Stack spacing={2}>
                 <TextField
                   label="Email"
@@ -87,8 +110,49 @@ export default function LoginPage() {
                   fullWidth
                   disabled={submitting}
                 >
-                  {submitting ? "Sending..." : "Send Magic Link"}
+                  {submitting ? "Sending..." : "Send Code"}
                 </Button>
+              </Stack>
+            </form>
+          ) : (
+            <form onSubmit={handleVerifyCode}>
+              <Stack spacing={2}>
+                <TextField
+                  label="6-digit code"
+                  value={code}
+                  onChange={(e) => setCode(e.target.value)}
+                  required
+                  fullWidth
+                  autoFocus
+                  inputMode="numeric"
+                  slotProps={{
+                    htmlInput: {
+                      maxLength: 6,
+                      pattern: "[0-9]*",
+                      style: { letterSpacing: "0.5em", textAlign: "center", fontSize: "1.25rem" },
+                    },
+                  }}
+                />
+                <Button
+                  type="submit"
+                  variant="contained"
+                  size="large"
+                  fullWidth
+                  disabled={submitting || code.trim().length < 6}
+                >
+                  {submitting ? "Verifying..." : "Sign In"}
+                </Button>
+                <Button
+                  variant="text"
+                  size="small"
+                  onClick={handleStartOver}
+                  disabled={submitting}
+                >
+                  Use a different email
+                </Button>
+                <Typography variant="caption" color="text.secondary" textAlign="center">
+                  Didn't get the code? Check your spam/junk folder.
+                </Typography>
               </Stack>
             </form>
           )}

--- a/src/admin-app/src/features/auth/LoginPage.jsx
+++ b/src/admin-app/src/features/auth/LoginPage.jsx
@@ -2,7 +2,7 @@
  * @file LoginPage.jsx
  * @summary Sign-in screen with two-step OTP code auth + a dev-login fallback.
  *
- * Step 1: user enters their email and we send them a 6-digit code via Supabase
+ * Step 1: user enters their email and we send them a 8-digit code via Supabase
  * Auth. Step 2: user enters the code and we exchange it for a session.
  *
  * Code entry instead of magic-link clicks because institutional email scanners
@@ -82,7 +82,7 @@ export default function LoginPage() {
           <Typography variant="body2" color="text.secondary" textAlign="center" mb={3}>
             {step === "email"
               ? "Sign in with your email"
-              : `Enter the 6-digit code we sent to ${email}`}
+              : `Enter the 8-digit code we sent to ${email}`}
           </Typography>
 
           {error && (
@@ -118,7 +118,7 @@ export default function LoginPage() {
             <form onSubmit={handleVerifyCode}>
               <Stack spacing={2}>
                 <TextField
-                  label="6-digit code"
+                  label="8-digit code"
                   value={code}
                   onChange={(e) => setCode(e.target.value)}
                   required
@@ -127,9 +127,9 @@ export default function LoginPage() {
                   inputMode="numeric"
                   slotProps={{
                     htmlInput: {
-                      maxLength: 6,
+                      maxLength: 8,
                       pattern: "[0-9]*",
-                      style: { letterSpacing: "0.5em", textAlign: "center", fontSize: "1.25rem" },
+                      style: { letterSpacing: "0.4em", textAlign: "center", fontSize: "1.25rem" },
                     },
                   }}
                 />
@@ -138,7 +138,7 @@ export default function LoginPage() {
                   variant="contained"
                   size="large"
                   fullWidth
-                  disabled={submitting || code.trim().length < 6}
+                  disabled={submitting || code.trim().length < 8}
                 >
                   {submitting ? "Verifying..." : "Sign In"}
                 </Button>


### PR DESCRIPTION
Magic-link click-through auth was unreliable because institutional email scanners (Microsoft Defender Safe Links on @stthomas.edu, plus Mimecast/Proofpoint at MPCA and similar) pre-fetch the one-time link URL on arrival and consume the token before the user can click. This switches the flow to a two-step code-entry form: step 1 sends a 6-digit code, step 2 verifies it. Same Supabase APIs underneath, just the UX changes. Closes #60.

## Required follow-up

Update the **Magic Link** email template in Supabase Dashboard (Authentication -> Email Templates) to display `{{ .Token }}` as a prominent 6-digit code instead of the magic-link button.