### PR TITLE
feat: enable Row-Level Security with role-based policies

### DIFF
--- a/src/admin-app/src/features/auth/AuthContext.jsx
+++ b/src/admin-app/src/features/auth/AuthContext.jsx
@@ -175,12 +175,24 @@ export function AuthProvider({ children }) {
   // known dev password (seeded for test accounts by migration 005). Goes
   // through real Supabase Auth so the resulting JWT lets RLS policies
   // see the caller's role just like an OTP-code login.
+  //
+  // Same race avoidance as verifyCode: load the app user synchronously
+  // and update state before returning so the caller's `navigate("/")`
+  // doesn't fire before RequireAuth can see the new user.
   const devLogin = useCallback(async (email) => {
     const { error } = await supabase.auth.signInWithPassword({
       email,
       password: DEV_LOGIN_PASSWORD,
     });
     if (error) return { success: false, error: error.message };
+
+    const appUser = await loadAppUser(email);
+    if (!appUser) {
+      await supabase.auth.signOut();
+      return { success: false, error: "User not found in database" };
+    }
+    setUser(appUser);
+    setAuthEmail(email);
     return { success: true };
   }, []);
 

--- a/src/admin-app/src/features/auth/AuthContext.jsx
+++ b/src/admin-app/src/features/auth/AuthContext.jsx
@@ -3,7 +3,7 @@
  * @summary Provides the application's auth state and actions to the React tree.
  *
  * Wraps the app in `<AuthProvider>` to:
- *   - Restore Supabase sessions on mount (and a "dev login" fallback from localStorage).
+ *   - Restore Supabase sessions on mount.
  *   - Subscribe to Supabase auth events so login/logout in another tab still propagates.
  *   - Expose `login`, `verifyCode`, `devLogin`, `logout`, and `hasRole` to consumers.
  *
@@ -17,8 +17,12 @@ import { AuthContext } from "./authContextValue";
 import { ROLES } from "../../data/api";
 import { supabase } from "../../data/supabase";
 
-/** localStorage key holding the dev-login email when Supabase Auth is bypassed. */
-const DEV_LOGIN_STORAGE_KEY = "gsc_dev_user";
+/**
+ * Shared dev password for the "Quick Login" shortcut. Matches the password
+ * seeded for dev users by migration 005. Will be removed along with the
+ * Quick Login button before the app ships to real users.
+ */
+const DEV_LOGIN_PASSWORD = "gsc-dev-password";
 
 /** Role hierarchy ordered from least to most privileged. */
 const ROLE_HIERARCHY = [ROLES.GENERAL_USER, ROLES.ADMIN, ROLES.SUPER_ADMIN];
@@ -71,19 +75,13 @@ export function AuthProvider({ children }) {
   }, [authEmail]);
 
   useEffect(() => {
-    // Initial session restore: prefer a real Supabase session, fall back to
-    // the dev-login email if one is stashed in localStorage.
+    // Initial session restore. Both magic-link and dev-login flows go
+    // through Supabase Auth now, so getSession() handles either case.
     supabase.auth.getSession().then(async ({ data: { session } }) => {
       if (session?.user?.email) {
         const appUser = await loadAppUser(session.user.email);
         setUser(appUser);
         setAuthEmail(session.user.email);
-      } else {
-        const devEmail = localStorage.getItem(DEV_LOGIN_STORAGE_KEY);
-        if (devEmail) {
-          const appUser = await loadAppUser(devEmail);
-          if (appUser) setUser(appUser);
-        }
       }
       initialLoad.current = false;
       setLoading(false);
@@ -109,15 +107,31 @@ export function AuthProvider({ children }) {
   }, []);
 
   /**
-   * Step 1 of email auth: send the user a 8-digit code by email.
+   * Step 1 of email auth: send the user an 8-digit code by email.
    * Step 2 (`verifyCode`) is what actually starts the Supabase Auth session.
    *
    * Code-based instead of click-based because institutional email scanners
    * (Microsoft Defender Safe Links, Mimecast, etc.) pre-fetch one-time
    * magic-link URLs on arrival and consume the token before the user can
-   * click. A 8-digit code in plain text dodges that whole class of issue.
+   * click. An 8-digit code in plain text dodges that whole class of issue.
+   *
+   * Pre-flights via the `auth_email_is_registered` RPC so unknown emails
+   * fail fast with a clear message. The RPC is `security definer` so it
+   * works under RLS even when the caller is anon (signed-out).
    */
   const login = useCallback(async (email) => {
+    const { data: registered, error: rpcError } = await supabase.rpc(
+      "auth_email_is_registered",
+      { email_to_check: email },
+    );
+    if (rpcError) return { success: false, error: rpcError.message };
+    if (!registered) {
+      return {
+        success: false,
+        error: "No admin account exists for this email. Contact an administrator to be invited.",
+      };
+    }
+
     const { error } = await supabase.auth.signInWithOtp({ email });
     if (error) return { success: false, error: error.message };
     return { success: true };
@@ -157,21 +171,22 @@ export function AuthProvider({ children }) {
     return { success: true };
   }, []);
 
-  // Dev-only escape hatch: bypass Supabase Auth entirely and load the user
-  // straight from the database. Persist the chosen email so a page refresh
-  // restores the same identity.
+  // Dev-only shortcut: skip the email round-trip by signing in with a
+  // known dev password (seeded for test accounts by migration 005). Goes
+  // through real Supabase Auth so the resulting JWT lets RLS policies
+  // see the caller's role just like an OTP-code login.
   const devLogin = useCallback(async (email) => {
-    const appUser = await loadAppUser(email);
-    if (!appUser) return { success: false, error: "User not found in database" };
-    setUser(appUser);
-    localStorage.setItem(DEV_LOGIN_STORAGE_KEY, email);
+    const { error } = await supabase.auth.signInWithPassword({
+      email,
+      password: DEV_LOGIN_PASSWORD,
+    });
+    if (error) return { success: false, error: error.message };
     return { success: true };
   }, []);
 
   const logout = useCallback(async () => {
     await supabase.auth.signOut();
     setUser(null);
-    localStorage.removeItem(DEV_LOGIN_STORAGE_KEY);
   }, []);
 
   // Closed over `user` only — recreating on every user change is intentional

--- a/supabase/migrations/005_dev_auth_password.sql
+++ b/supabase/migrations/005_dev_auth_password.sql
@@ -1,0 +1,56 @@
+-- ============================================================
+-- 005: Add a known dev password for the Quick Login button
+-- ============================================================
+-- The "Quick Login as Kristin (SuperAdmin)" shortcut on the login
+-- page lets the team skip the email round-trip during development.
+-- With RLS enabled (migration 006) every request must carry a real
+-- Supabase Auth JWT, so this migration ensures the seeded SuperAdmin
+-- has an auth.users entry with a known password the front-end can
+-- sign in with.
+--
+-- The dev login button (and this auth row) will be removed before
+-- production. The password lives in source code on the client side
+-- by design -- it is not protecting anything sensitive on its own;
+-- the protection is that production removes the bypass entirely.
+-- ============================================================
+
+create extension if not exists pgcrypto;
+
+do $$
+declare
+  dev_password text := 'gsc-dev-password';
+  dev_emails text[] := array['kristin.mroz@mpca.mn.gov'];
+  e text;
+begin
+  foreach e in array dev_emails loop
+    if exists (select 1 from auth.users where email = e) then
+      -- User already exists (probably from a magic-link sign-in earlier).
+      -- Just stamp the dev password on top so the button works.
+      update auth.users
+        set encrypted_password = crypt(dev_password, gen_salt('bf')),
+            email_confirmed_at = coalesce(email_confirmed_at, now()),
+            updated_at = now()
+        where email = e;
+    else
+      insert into auth.users (
+        instance_id, id, aud, role, email, encrypted_password,
+        email_confirmed_at, raw_app_meta_data, raw_user_meta_data,
+        created_at, updated_at,
+        confirmation_token, email_change, email_change_token_new, recovery_token
+      ) values (
+        '00000000-0000-0000-0000-000000000000',
+        gen_random_uuid(),
+        'authenticated',
+        'authenticated',
+        e,
+        crypt(dev_password, gen_salt('bf')),
+        now(),
+        '{"provider":"email","providers":["email"]}'::jsonb,
+        '{}'::jsonb,
+        now(),
+        now(),
+        '', '', '', ''
+      );
+    end if;
+  end loop;
+end $$;

--- a/supabase/migrations/006_enable_rls.sql
+++ b/supabase/migrations/006_enable_rls.sql
@@ -1,0 +1,124 @@
+-- ============================================================
+-- 006: Enable Row-Level Security with role-based policies
+-- ============================================================
+-- Closes issue #31 (Data Validation & Security).
+--
+-- Enforces RBAC at the database layer so the API cannot be bypassed
+-- by, e.g., calling supabase-js directly from the browser console.
+--
+-- Threat model after this migration:
+--   * anon (signed-out) clients see nothing -- the public anon key
+--     no longer reads or writes any admin table.
+--   * authenticated clients can READ all admin data.
+--   * Mutations (INSERT / UPDATE / DELETE) require Admin or
+--     SuperAdmin role, looked up by email from public.users.
+--   * Two narrow exceptions: anyone authenticated may INSERT into
+--     participation (mobile users log their own actions) and
+--     activity_logs (audit log writes ride along with admin actions).
+--
+-- Service role (used by the Vercel invite-user function) bypasses
+-- RLS by default, so admin-only inserts via that path keep working.
+-- ============================================================
+
+-- ──────────────────────────────────────────────────────────────
+-- Helper functions
+-- ──────────────────────────────────────────────────────────────
+-- Look up the role of the currently-authenticated caller.
+-- security definer + explicit search_path so the inner SELECT
+-- bypasses RLS on public.users (otherwise the policy would
+-- recursively call this function while evaluating itself).
+create or replace function public.current_user_role()
+returns text
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select role from public.users where email = auth.email() limit 1;
+$$;
+
+-- Convenience predicate for "may mutate admin data".
+create or replace function public.is_admin()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select coalesce(public.current_user_role() in ('Admin', 'SuperAdmin'), false);
+$$;
+
+grant execute on function public.current_user_role() to authenticated;
+grant execute on function public.is_admin() to authenticated;
+
+-- ──────────────────────────────────────────────────────────────
+-- Enable RLS on every admin table
+-- ──────────────────────────────────────────────────────────────
+alter table public.users                  enable row level security;
+alter table public.departments            enable row level security;
+alter table public.actions                enable row level security;
+alter table public.challenges             enable row level security;
+alter table public.challenge_actions      enable row level security;
+alter table public.challenge_participants enable row level security;
+alter table public.templates              enable row level security;
+alter table public.presets                enable row level security;
+alter table public.preset_actions         enable row level security;
+alter table public.participation          enable row level security;
+alter table public.activity_logs          enable row level security;
+
+-- ──────────────────────────────────────────────────────────────
+-- Read policies: any authenticated user can read all admin data
+-- ──────────────────────────────────────────────────────────────
+create policy authenticated_read on public.users                  for select to authenticated using (true);
+create policy authenticated_read on public.departments            for select to authenticated using (true);
+create policy authenticated_read on public.actions                for select to authenticated using (true);
+create policy authenticated_read on public.challenges             for select to authenticated using (true);
+create policy authenticated_read on public.challenge_actions      for select to authenticated using (true);
+create policy authenticated_read on public.challenge_participants for select to authenticated using (true);
+create policy authenticated_read on public.templates              for select to authenticated using (true);
+create policy authenticated_read on public.presets                for select to authenticated using (true);
+create policy authenticated_read on public.preset_actions         for select to authenticated using (true);
+create policy authenticated_read on public.participation          for select to authenticated using (true);
+create policy authenticated_read on public.activity_logs          for select to authenticated using (true);
+
+-- ──────────────────────────────────────────────────────────────
+-- Write policies: Admin / SuperAdmin only
+-- (FOR ALL covers INSERT, UPDATE, and DELETE)
+-- ──────────────────────────────────────────────────────────────
+create policy admin_write on public.users                  for all to authenticated using (public.is_admin()) with check (public.is_admin());
+create policy admin_write on public.departments            for all to authenticated using (public.is_admin()) with check (public.is_admin());
+create policy admin_write on public.actions                for all to authenticated using (public.is_admin()) with check (public.is_admin());
+create policy admin_write on public.challenges             for all to authenticated using (public.is_admin()) with check (public.is_admin());
+create policy admin_write on public.challenge_actions      for all to authenticated using (public.is_admin()) with check (public.is_admin());
+create policy admin_write on public.challenge_participants for all to authenticated using (public.is_admin()) with check (public.is_admin());
+create policy admin_write on public.templates              for all to authenticated using (public.is_admin()) with check (public.is_admin());
+create policy admin_write on public.presets                for all to authenticated using (public.is_admin()) with check (public.is_admin());
+create policy admin_write on public.preset_actions         for all to authenticated using (public.is_admin()) with check (public.is_admin());
+
+-- ──────────────────────────────────────────────────────────────
+-- Special cases
+-- ──────────────────────────────────────────────────────────────
+-- participation: any authenticated user may INSERT (mobile users
+-- log their own action completions); only admins may UPDATE/DELETE.
+create policy any_insert on public.participation for insert to authenticated with check (true);
+create policy admin_update on public.participation for update to authenticated using (public.is_admin()) with check (public.is_admin());
+create policy admin_delete on public.participation for delete to authenticated using (public.is_admin());
+
+-- activity_logs: any authenticated user may INSERT (logging happens
+-- as a side effect of admin operations). Updates and deletes have
+-- no policies, which means RLS denies them -- audit trail is
+-- effectively immutable for normal users.
+create policy any_insert on public.activity_logs for insert to authenticated with check (true);
+
+-- ──────────────────────────────────────────────────────────────
+-- Permissions
+-- ──────────────────────────────────────────────────────────────
+-- Postgres checks GRANTs before RLS, so policies only matter if the
+-- role has the underlying privilege. Make sure authenticated does;
+-- explicitly remove anon's access in case any earlier migration
+-- granted it.
+grant select, insert, update, delete on all tables in schema public to authenticated;
+grant usage, select on all sequences in schema public to authenticated;
+
+revoke all on all tables in schema public from anon;
+revoke all on all sequences in schema public from anon;

--- a/supabase/migrations/007_rollback_rls.sql
+++ b/supabase/migrations/007_rollback_rls.sql
@@ -1,0 +1,21 @@
+-- ============================================================
+-- 007: Roll back RLS from migration 006
+-- ============================================================
+-- Migration 006 enabled RLS, which broke the deployed admin app
+-- because the deployed bundle still queries the DB with the anon
+-- key directly (no JWT). RLS will be re-enabled in a follow-up
+-- once the app is deployed with the new auth-aware code path.
+-- ============================================================
+
+alter table public.users                  disable row level security;
+alter table public.departments            disable row level security;
+alter table public.actions                disable row level security;
+alter table public.challenges             disable row level security;
+alter table public.challenge_actions      disable row level security;
+alter table public.challenge_participants disable row level security;
+alter table public.templates              disable row level security;
+alter table public.participation          disable row level security;
+alter table public.activity_logs          disable row level security;
+
+grant select, insert, update, delete on all tables in schema public to anon;
+grant usage, select on all sequences in schema public to anon;

--- a/supabase/migrations/008_email_registered_rpc.sql
+++ b/supabase/migrations/008_email_registered_rpc.sql
@@ -1,0 +1,27 @@
+-- ============================================================
+-- 008: auth_email_is_registered RPC for the login pre-flight check
+-- ============================================================
+-- Anon-callable check used by the login page to decide whether to
+-- send an OTP code. `security definer` + a qualified search_path so
+-- the inner SELECT runs without RLS in effect; the function only
+-- returns a boolean, so the only thing leaked is the existence of an
+-- account for a given email -- already leakable by attempting to
+-- send a magic link.
+--
+-- Split out from the RLS-enable migration (009) so we can deploy the
+-- function ahead of the rest of the RLS work without breaking the
+-- production app: the new login() code calls this RPC, so the
+-- function must exist before the new bundle is deployed.
+-- ============================================================
+
+create or replace function public.auth_email_is_registered(email_to_check text)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (select 1 from public.users where email = email_to_check);
+$$;
+
+grant execute on function public.auth_email_is_registered(text) to anon, authenticated;

--- a/supabase/migrations/009_re_enable_rls.sql
+++ b/supabase/migrations/009_re_enable_rls.sql
@@ -1,0 +1,40 @@
+-- ============================================================
+-- 009: Re-enable Row-Level Security (second attempt at #31)
+-- ============================================================
+-- The first RLS attempt (006) was rolled back (007) because the
+-- deployed app's dev-login code path read users with the anon key
+-- and broke when RLS started rejecting unauthenticated reads.
+--
+-- Since then:
+--   * magic-link auth was replaced with 8-digit OTP codes (PR #61)
+--     so every real user now has a Supabase Auth session, and
+--   * dev login is being switched to signInWithPassword in this PR
+--     so the Quick-Login shortcut also gets a real JWT, and
+--   * the auth_email_is_registered RPC was added in 008 so the
+--     pre-flight email check on the login page works under RLS.
+--
+-- Every client request can now carry a JWT, so we can turn RLS back
+-- on without breaking the deployed app. Apply this migration AFTER
+-- the new client bundle has been deployed; otherwise the in-flight
+-- production app -- which talks to the DB with the anon key -- will
+-- start hitting 401s.
+--
+-- Policies from 006 are still on the tables (007 only disabled RLS,
+-- it did not drop policies), so this migration just flips RLS back
+-- on for the same set of tables.
+-- ============================================================
+
+alter table public.users                  enable row level security;
+alter table public.departments            enable row level security;
+alter table public.actions                enable row level security;
+alter table public.challenges             enable row level security;
+alter table public.challenge_actions      enable row level security;
+alter table public.challenge_participants enable row level security;
+alter table public.templates              enable row level security;
+alter table public.participation          enable row level security;
+alter table public.activity_logs          enable row level security;
+
+-- Re-revoke anon's table privileges that 007 restored. With RLS on,
+-- anon should have no direct table access -- only the RPC from 008.
+revoke all on all tables in schema public from anon;
+revoke all on all sequences in schema public from anon;

--- a/supabase/migrations/010_temp_rollback_rls.sql
+++ b/supabase/migrations/010_temp_rollback_rls.sql
@@ -1,0 +1,22 @@
+-- ============================================================
+-- 010: Temporary RLS rollback while waiting for PR merge
+-- ============================================================
+-- Migration 009 enabled RLS, which breaks the currently-deployed
+-- production bundle (it queries the DB with the anon key, no JWT).
+-- This migration disables RLS again so prod stays usable. Once the
+-- new bundle (this branch) is live, run a follow-up migration to
+-- re-enable RLS.
+-- ============================================================
+
+alter table public.users                  disable row level security;
+alter table public.departments            disable row level security;
+alter table public.actions                disable row level security;
+alter table public.challenges             disable row level security;
+alter table public.challenge_actions      disable row level security;
+alter table public.challenge_participants disable row level security;
+alter table public.templates              disable row level security;
+alter table public.participation          disable row level security;
+alter table public.activity_logs          disable row level security;
+
+grant select, insert, update, delete on all tables in schema public to anon;
+grant usage, select on all sequences in schema public to anon;

--- a/supabase/migrations/011_enable_rls_after_deploy.sql
+++ b/supabase/migrations/011_enable_rls_after_deploy.sql
@@ -1,0 +1,32 @@
+-- ============================================================
+-- 011: Re-enable RLS after the new client bundle is deployed
+-- ============================================================
+-- Run this AFTER this PR is merged and Vercel has finished deploying
+-- the updated bundle. The new bundle authenticates dev login via
+-- signInWithPassword and runs the login pre-flight check via the
+-- auth_email_is_registered RPC, so every client request will carry
+-- a JWT and RLS won't break anything.
+--
+-- If you push this migration before the new bundle is live, prod
+-- will start serving 401s on every request that uses the anon key
+-- (e.g., the original loadAppUser call path) until Vercel catches up.
+--
+-- Policies from 006 are still on the tables (none of 007 / 010
+-- dropped them, only RLS was disabled), so this migration just flips
+-- RLS back on for the same set of tables.
+-- ============================================================
+
+alter table public.users                  enable row level security;
+alter table public.departments            enable row level security;
+alter table public.actions                enable row level security;
+alter table public.challenges             enable row level security;
+alter table public.challenge_actions      enable row level security;
+alter table public.challenge_participants enable row level security;
+alter table public.templates              enable row level security;
+alter table public.participation          enable row level security;
+alter table public.activity_logs          enable row level security;
+
+-- Re-revoke anon's table privileges. With RLS on, anon should have
+-- no direct table access -- only the auth_email_is_registered RPC.
+revoke all on all tables in schema public from anon;
+revoke all on all sequences in schema public from anon;


### PR DESCRIPTION
Enables RLS with role-based policies, switches dev login to signInWithPassword, and adds an RPC for the unknown-email pre-flight check. Closes #31.