### PR TITLE
fix: block deactivated users from signing in

### DIFF
--- a/src/admin-app/api/set-user-active.js
+++ b/src/admin-app/api/set-user-active.js
@@ -1,0 +1,48 @@
+import { createClient } from "@supabase/supabase-js";
+
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+// "Permanent" ban for deactivated users -- 100 years out. Supabase Auth
+// requires a positive ban_duration string; null/'none' lifts the ban.
+const PERMANENT_BAN = "876600h";
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+  if (!supabaseUrl || !serviceRoleKey) {
+    return res.status(500).json({ error: "Server misconfigured" });
+  }
+
+  const { email, active } = req.body || {};
+  if (!email || typeof active !== "boolean") {
+    return res.status(400).json({ error: "email and active are required" });
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  // No getUserByEmail in the admin API; list and filter. Page size of 1000
+  // is fine at our scale.
+  const { data: list, error: listError } = await supabase.auth.admin.listUsers({
+    page: 1,
+    perPage: 1000,
+  });
+  if (listError) return res.status(500).json({ error: listError.message });
+
+  const authUser = list.users.find((u) => u.email === email);
+  if (!authUser) {
+    // The profile row exists but the auth row doesn't -- they were never
+    // signed in. Nothing to ban; client side will still gate via status.
+    return res.status(200).json({ ok: true, skipped: "no auth user" });
+  }
+
+  const { error: updateError } = await supabase.auth.admin.updateUserById(authUser.id, {
+    ban_duration: active ? "none" : PERMANENT_BAN,
+  });
+  if (updateError) return res.status(500).json({ error: updateError.message });
+
+  return res.status(200).json({ ok: true });
+}

--- a/src/admin-app/src/data/api/users.js
+++ b/src/admin-app/src/data/api/users.js
@@ -58,20 +58,48 @@ export async function updateUser(id, data) {
 }
 
 /**
- * Mark a user as Deactivated. We never hard-delete users so participation
- * history and activity logs remain queryable.
+ * Mark a user as Deactivated and ban their auth credentials so they
+ * actually can't sign in anymore.
  * @param {number|string} id
  */
 export async function deactivateUser(id) {
-  return updateUser(id, { status: USER_STATUSES.DEACTIVATED });
+  const updated = await updateUser(id, { status: USER_STATUSES.DEACTIVATED });
+  await setAuthActive(updated.email, false);
+  return updated;
 }
 
 /**
- * Re-activate a previously deactivated user.
+ * Re-activate a previously deactivated user, restoring sign-in.
  * @param {number|string} id
  */
 export async function activateUser(id) {
-  return updateUser(id, { status: USER_STATUSES.ACTIVE });
+  const updated = await updateUser(id, { status: USER_STATUSES.ACTIVE });
+  await setAuthActive(updated.email, true);
+  return updated;
+}
+
+/**
+ * Toggle the Supabase Auth ban for an email via the service-role
+ * serverless function. Failures here are logged but not thrown so a
+ * missing auth row doesn't block the profile-side status flip.
+ */
+async function setAuthActive(email, active) {
+  if (!email) return;
+  try {
+    const res = await fetch("/api/set-user-active", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, active }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      // eslint-disable-next-line no-console
+      console.warn("set-user-active failed:", body.error || res.statusText);
+    }
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn("set-user-active failed:", err.message);
+  }
 }
 
 /**

--- a/src/admin-app/src/features/auth/AuthContext.jsx
+++ b/src/admin-app/src/features/auth/AuthContext.jsx
@@ -14,7 +14,7 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 
 import { AuthContext } from "./authContextValue";
-import { ROLES } from "../../data/api";
+import { ROLES, USER_STATUSES } from "../../data/api";
 import { supabase } from "../../data/supabase";
 
 /**
@@ -36,6 +36,31 @@ async function loadAppUser(email) {
   const { data, error } = await supabase.from("users").select("*").eq("email", email).single();
   if (error || !data) return null;
   return data;
+}
+
+/**
+ * Post-auth gate: load the user's profile row and verify they're allowed
+ * to use the admin app (exists in `users` and not deactivated). On any
+ * failure, drop the just-established Supabase Auth session so the user
+ * isn't left half-signed-in.
+ */
+async function authorizeOrSignOut(email) {
+  const appUser = await loadAppUser(email);
+  if (!appUser) {
+    await supabase.auth.signOut();
+    return {
+      success: false,
+      error: "No admin account exists for this email. Contact an administrator to be invited.",
+    };
+  }
+  if (appUser.status === USER_STATUSES.DEACTIVATED) {
+    await supabase.auth.signOut();
+    return {
+      success: false,
+      error: "This account has been deactivated. Contact an administrator if you think this is a mistake.",
+    };
+  }
+  return { success: true, appUser };
 }
 
 /**
@@ -155,18 +180,9 @@ export function AuthProvider({ children }) {
     });
     if (error) return { success: false, error: error.message };
 
-    const appUser = await loadAppUser(email);
-    if (!appUser) {
-      // Supabase auth accepted the code but this email has no row in
-      // public.users -- they're not an admin. Drop the session and
-      // surface a clear error.
-      await supabase.auth.signOut();
-      return {
-        success: false,
-        error: "No admin account exists for this email. Contact an administrator to be invited.",
-      };
-    }
-    setUser(appUser);
+    const guard = await authorizeOrSignOut(email);
+    if (!guard.success) return guard;
+    setUser(guard.appUser);
     setAuthEmail(email);
     return { success: true };
   }, []);
@@ -186,12 +202,9 @@ export function AuthProvider({ children }) {
     });
     if (error) return { success: false, error: error.message };
 
-    const appUser = await loadAppUser(email);
-    if (!appUser) {
-      await supabase.auth.signOut();
-      return { success: false, error: "User not found in database" };
-    }
-    setUser(appUser);
+    const guard = await authorizeOrSignOut(email);
+    if (!guard.success) return guard;
+    setUser(guard.appUser);
     setAuthEmail(email);
     return { success: true };
   }, []);

--- a/supabase/migrations/012_email_registered_active_only.sql
+++ b/supabase/migrations/012_email_registered_active_only.sql
@@ -1,0 +1,22 @@
+-- ============================================================
+-- 012: auth_email_is_registered should ignore deactivated users
+-- ============================================================
+-- Otherwise the login pre-flight passes for deactivated emails and
+-- sends them a code they can't actually use; they only see the
+-- "deactivated" error after entering it. Filtering on status here
+-- shifts the error to before the code is sent.
+-- ============================================================
+
+create or replace function public.auth_email_is_registered(email_to_check text)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1 from public.users
+    where email = email_to_check
+      and status = 'Active'
+  );
+$$;


### PR DESCRIPTION
Bans the auth credentials via a new `/api/set-user-active` serverless function on deactivate/reactivate, plus a client-side status check that signs them back out if they slip through. Closes #64.