### PR TITLE
Add SuperAdmin permanent user delete (#67)

### DIFF
--- a/src/admin-app/api/delete-user.js
+++ b/src/admin-app/api/delete-user.js
@@ -1,0 +1,72 @@
+/**
+ * @file delete-user.js
+ * @summary Vercel API route -- permanent SuperAdmin user delete.
+ *
+ * Counterpart to `set-user-active.js` (deactivate). Where deactivate
+ * just bans the auth credential and flips a status flag, this route
+ * fully purges the user from both Supabase Auth and the app `users`
+ * table.
+ *
+ * Cascade behavior is encoded in the schema (migration 001):
+ *   - `participation."userId"`  ON DELETE CASCADE  -> rows go away
+ *   - `activity_logs."userId"`  ON DELETE CASCADE  -> rows go away
+ *   - `*.createdBy`             ON DELETE SET NULL -> author becomes null
+ *
+ * Net effect: the user disappears, their action completions disappear
+ * (because they no longer count), and anything they authored
+ * (challenges, templates, groups) survives but anonymized.
+ *
+ * Authorization is handled by the frontend (SuperAdmin-only button)
+ * AND by the service-role key being server-only -- the frontend can't
+ * call Supabase admin APIs directly.
+ */
+
+import { createClient } from "@supabase/supabase-js";
+
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+  if (!supabaseUrl || !serviceRoleKey) {
+    return res.status(500).json({ error: "Server misconfigured" });
+  }
+
+  const { userId, email } = req.body || {};
+  if (!userId || !email) {
+    return res.status(400).json({ error: "userId and email are required" });
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  // Step 1 -- find the auth.users row by email so we can call deleteUser
+  // with its UUID. listUsers maxes at 1000 per page; fine at our scale.
+  // If the user never signed in there's no auth row to delete; that's
+  // not a failure -- we still want to drop the app-side row.
+  const { data: list, error: listError } = await supabase.auth.admin.listUsers({
+    page: 1,
+    perPage: 1000,
+  });
+  if (listError) return res.status(500).json({ error: listError.message });
+
+  const authUser = list.users.find((u) => u.email === email);
+  if (authUser) {
+    const { error: authDeleteError } = await supabase.auth.admin.deleteUser(authUser.id);
+    if (authDeleteError) {
+      return res.status(500).json({ error: authDeleteError.message });
+    }
+  }
+
+  // Step 2 -- delete the app users row. FK cascades clean up
+  // participation + activity_logs; createdBy refs go to NULL.
+  const { error: rowDeleteError } = await supabase.from("users").delete().eq("id", userId);
+  if (rowDeleteError) {
+    return res.status(500).json({ error: rowDeleteError.message });
+  }
+
+  return res.status(200).json({ ok: true, authDeleted: !!authUser });
+}

--- a/src/admin-app/src/data/api/users.js
+++ b/src/admin-app/src/data/api/users.js
@@ -113,3 +113,31 @@ export async function getUserByEmail(email) {
   const { data } = await supabase.from("users").select("*").eq("email", email).maybeSingle();
   return data;
 }
+
+/**
+ * Permanently delete a user (Auth + profile row) via the serverless
+ * delete endpoint. Distinct from `deactivateUser`, which only bans
+ * the credential and flips a status flag; this purges the user
+ * entirely. Cascades to `participation` and `activity_logs`; rows
+ * the user authored (challenges, templates, groups) keep a NULL
+ * `createdBy`.
+ *
+ * SuperAdmin-only. The frontend gates the affordance via
+ * `can(role, "DELETE_USER_PERMANENT")`; the service-role key is
+ * server-only so the route can't be called from a regular client
+ * even if someone bypasses the UI guard.
+ *
+ * @param {{ id: number|string, email: string }} user The user row to purge.
+ * @returns {Promise<{ ok: boolean, authDeleted: boolean }>}
+ * @throws {Error} When the serverless function responds with a non-2xx.
+ */
+export async function deleteUserPermanently({ id, email }) {
+  const res = await fetch("/api/delete-user", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ userId: id, email }),
+  });
+  const result = await res.json();
+  if (!res.ok) throw new Error(result.error || "Failed to delete user");
+  return result;
+}

--- a/src/admin-app/src/features/users/UsersPage.jsx
+++ b/src/admin-app/src/features/users/UsersPage.jsx
@@ -29,6 +29,7 @@ import {
   USER_STATUSES,
   activateUser,
   deactivateUser,
+  deleteUserPermanently,
   getGroups,
   getUsers,
   logActivity,
@@ -52,12 +53,15 @@ export default function UsersPage() {
   const [error, setError] = useState(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [pendingAction, setPendingAction] = useState(null);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState(null);
 
   const navigate = useNavigate();
   const { user, hasRole } = useAuth();
   const userRole = user?.role || ROLES.GENERAL_USER;
   const canManage = hasRole("Admin");
   const isSuperAdmin = hasRole("SuperAdmin");
+  const canDeletePermanent = can(userRole, "DELETE_USER_PERMANENT");
 
   // Column-visibility flags driven by the permissions matrix.
   const cols = {
@@ -115,6 +119,33 @@ export default function UsersPage() {
     setPendingAction(null);
     setConfirmOpen(false);
     load();
+  };
+
+  const requestDeletePermanent = (target) => {
+    setPendingDelete(target);
+    setDeleteConfirmOpen(true);
+  };
+
+  // Activity log row is written BEFORE the delete -- otherwise the FK
+  // cascade on activity_logs.userId would wipe out the audit entry too.
+  const handleDeletePermanent = async () => {
+    if (!pendingDelete) return;
+    setError(null);
+    try {
+      await logActivity(
+        user.id,
+        "Permanently deleted user",
+        `Permanently deleted ${pendingDelete.name} (${pendingDelete.email})`,
+      );
+      await deleteUserPermanently({ id: pendingDelete.id, email: pendingDelete.email });
+      setPendingDelete(null);
+      setDeleteConfirmOpen(false);
+      load();
+    } catch (err) {
+      setError(err.message || "Failed to permanently delete user");
+      setDeleteConfirmOpen(false);
+      setPendingDelete(null);
+    }
   };
 
   if (loading) {
@@ -179,7 +210,9 @@ export default function UsersPage() {
         groupName={groupName}
         cols={cols}
         canManage={canManage}
+        canDeletePermanent={canDeletePermanent}
         onToggleStatus={requestToggleStatus}
+        onDeletePermanent={requestDeletePermanent}
       />
 
       <ConfirmDialog
@@ -192,6 +225,25 @@ export default function UsersPage() {
         onCancel={() => {
           setConfirmOpen(false);
           setPendingAction(null);
+        }}
+      />
+
+      <ConfirmDialog
+        open={deleteConfirmOpen}
+        title="Permanently delete user?"
+        message={
+          pendingDelete
+            ? `This will permanently delete ${pendingDelete.name} (${pendingDelete.email}), ` +
+              "their sign-in credential, all of their action completions, and their activity " +
+              "log. Anything they authored (challenges, templates, groups) will remain but " +
+              "show no author. This cannot be undone -- prefer Deactivate if you only need " +
+              "to block sign-in."
+            : ""
+        }
+        onConfirm={handleDeletePermanent}
+        onCancel={() => {
+          setDeleteConfirmOpen(false);
+          setPendingDelete(null);
         }}
       />
     </Box>

--- a/src/admin-app/src/features/users/components/UsersTable.jsx
+++ b/src/admin-app/src/features/users/components/UsersTable.jsx
@@ -11,6 +11,7 @@ import { useNavigate } from "react-router-dom";
 
 import BlockIcon from "@mui/icons-material/Block";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import DeleteForeverIcon from "@mui/icons-material/DeleteForever";
 import EditIcon from "@mui/icons-material/Edit";
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import {
@@ -46,9 +47,19 @@ import { USER_STATUSES } from "../../../data/api";
  * @param {(gid: number) => string} props.groupName  - id-to-name lookup
  * @param {ColumnPerms}    props.cols
  * @param {boolean}        props.canManage  - show Edit / toggle-status icons
+ * @param {boolean}        props.canDeletePermanent  - show permanent-delete icon (SuperAdmin)
  * @param {(user: object) => void} props.onToggleStatus  - asks parent to confirm
+ * @param {(user: object) => void} [props.onDeletePermanent]  - asks parent to confirm permanent delete
  */
-export default function UsersTable({ users, groupName, cols, canManage, onToggleStatus }) {
+export default function UsersTable({
+  users,
+  groupName,
+  cols,
+  canManage,
+  canDeletePermanent,
+  onToggleStatus,
+  onDeletePermanent,
+}) {
   const navigate = useNavigate();
 
   // colSpan for the empty-state row: name + actions = 2, plus one
@@ -128,6 +139,16 @@ export default function UsersTable({ users, groupName, cols, canManage, onToggle
                       )}
                     </IconButton>
                   </>
+                )}
+                {canDeletePermanent && (
+                  <IconButton
+                    size="small"
+                    color="error"
+                    aria-label="Permanently delete user"
+                    onClick={() => onDeletePermanent?.(u)}
+                  >
+                    <DeleteForeverIcon fontSize="small" />
+                  </IconButton>
                 )}
               </TableCell>
             </TableRow>

--- a/src/admin-app/src/lib/permissions.js
+++ b/src/admin-app/src/lib/permissions.js
@@ -67,6 +67,13 @@ export const PERMS = {
   /** Who can activate/deactivate users */
   ACTIVATE_DEACTIVATE_USER: ROLES.ADMIN,
 
+  /**
+   * Who can permanently delete a user (auth + profile row + cascaded
+   * participation/activity_logs). Distinct from deactivate; this is
+   * irreversible. SuperAdmin only.
+   */
+  DELETE_USER_PERMANENT: ROLES.SUPER_ADMIN,
+
   // ─── Future: scope to specific users (e.g. GeneralUser sees only same group) ───
   // When needed, add: canViewUser(userId, viewerUserId, viewerRole, viewerGroupId)
   // and filter the users list / block detail access accordingly.


### PR DESCRIPTION
## Summary

Implements #67 — a SuperAdmin-only "permanent delete" affordance in the
Users list. Replaces the abandoned Netlify-era flow from #55 with a
Vercel API route that mirrors the existing \`set-user-active.js\` pattern.

Closes #67

## What this does

- New Vercel API route \`src/admin-app/api/delete-user.js\`:
  - Service-role Supabase client (server-only)
  - Deletes the auth.users row via \`auth.admin.deleteUser\` (skipped cleanly if the user never signed in)
  - Deletes the app users row; FK cascades handle the rest
- New data-API binding \`deleteUserPermanently()\` in \`data/api/users.js\`, auto-re-exported via the barrel
- New permission \`DELETE_USER_PERMANENT\` in \`lib/permissions.js\` (SuperAdmin only)
- New row-action icon (\`DeleteForeverIcon\`) in \`UsersTable\`, gated on the permission
- New ConfirmDialog flow on \`UsersPage\` with explicit copy distinguishing it from Deactivate

## Cascade behavior

The schema (migration 001) already encodes the cascade decision, so we don't have to make a new policy choice:

| Table | FK | On delete |
|---|---|---|
| \`participation\` | \`userId\` | **CASCADE** — completions are tied to the user |
| \`activity_logs\` | \`userId\` | **CASCADE** — log entries are tied to the user |
| \`groups\` | \`createdBy\` | **SET NULL** — group survives, author becomes null |
| \`challenges\` | \`createdBy\` | **SET NULL** — same |
| \`templates\` | \`createdBy\` | **SET NULL** — same |
| \`themes\`, \`tickets\` | \`createdBy\`, \`assignedTo\` | **SET NULL** — same |

So Postgres handles the cascade for us once we delete the \`users\` row. No new migration needed.

## Audit trail

The activity log entry for the delete is written **before** the delete call so the cascade on \`activity_logs.userId\` doesn't wipe the audit record along with the user. Acting SuperAdmin's \`user.id\` is the row author, not the deleted user, so the entry survives.

## Coverage check vs CODING_GUIDELINES.md

- §3 file-header docblock on every new/touched file ✓
- §3 JSDoc on all exported \`data/api\` functions ✓
- §5 \`<ConfirmDialog>\` before destructive action ✓ (separate dialog with explicit "cannot be undone" copy)
- §5 all data access through \`data/api\` barrel ✓
- §5 permission check via \`can()\` helper ✓
- §1 double quotes, semicolons, trailing commas, import order ✓
- §4 branch name \`feature/superadmin-delete-user\` matches \`<type>/<short-description>\` ✓
- §4 commit messages: capitalized imperative, no period ✓

## Verification

- \`npm run build\` — clean (vite 7.3.2, 1782 modules, 2.15s)
- \`npm run lint\` — adds **zero** new errors/warnings (baseline = 7 errors / 14 warnings, all pre-existing in \`presets/\` + the existing \`useEffect(load)\` pattern)

## Conflict notes

- **PR #68 (Reports widget)** also touches \`data/api/users.js\` but only adds a query helper — additive, trivial rebase
- **PR #73 (presentation prep)** doesn't overlap
- **PR #72 (Rudy)** doesn't overlap

## Test plan

- [ ] \`npm install && npm run dev\`
- [ ] Sign in as SuperAdmin → Users list → delete-forever icon appears beside the existing actions
- [ ] Sign in as Admin → delete-forever icon should **not** appear (only existing edit + deactivate icons)
- [ ] Sign in as GeneralUser → existing behavior (no manage icons at all)
- [ ] As SuperAdmin, click delete-forever on a test user that has at least one participation row + at least one activity log entry
- [ ] Confirm in the dialog → user disappears from the list, error stays empty
- [ ] In Supabase dashboard: confirm \`auth.users\` row is gone, \`users\` row is gone, that user's \`participation\` rows are gone, their \`activity_logs\` rows are gone, but any challenges/templates/groups they authored survive with \`createdBy = NULL\`
- [ ] Confirm an audit row exists in \`activity_logs\` for the SuperAdmin who did the delete
- [ ] Try delete on a user who never signed in (\`auth.users\` row missing) — should still purge the app row cleanly
- [ ] Cancel the dialog — nothing happens, user still in list