### PR TITLE
fix: add 4-color palette columns to challenges (#82)

### DIFF
--- a/supabase/migrations/014_challenge_split_colors.sql
+++ b/supabase/migrations/014_challenge_split_colors.sql
@@ -1,0 +1,13 @@
+-- ============================================================
+-- Migration: 014_challenge_split_colors.sql
+-- Description: Adds the 4-color palette columns the ChallengeForm
+--              has been writing to. The legacy single `theme` text
+--              column stays in place so existing rows keep rendering;
+--              new rows populate the four split columns.
+-- ============================================================
+
+alter table challenges
+  add column if not exists "bgColorHeader" varchar(7),
+  add column if not exists "txColorHeader" varchar(7),
+  add column if not exists "bgColorBody"   varchar(7),
+  add column if not exists "txColorBody"   varchar(7);


### PR DESCRIPTION
Closes #82. The live \`challenges\` table only had the legacy single \`theme text\` column, but the form has always written four separate colors (\`bgColorHeader\`, \`txColorHeader\`, \`bgColorBody\`, \`txColorBody\`). Adds those four columns so the form's existing payload round-trips cleanly.

The migration has already been applied to the live DB via \`supabase db push\` from this branch.

## Test plan
- [ ] Quick Login as Kristin
- [ ] Challenges → New Challenge → fill in name, dates, pick all 4 colors → click Create Challenge → expect redirect to /challenges with no console error
- [ ] Refresh /challenges → new challenge appears
- [ ] Open the row in Supabase → \`bgColorHeader\`, \`txColorHeader\`, \`bgColorBody\`, \`txColorBody\` are populated

## Background
The repo's \`migrations/001_initial_schema.sql\` describes a redesigned normalized schema (themes table, categoryId FK, etc.) that was never deployed — live is still the older denormalized layout. My first attempt at this PR reshaped the form to that phantom schema and got rejected by the live DB. Reverted; this PR is just the additive column migration. Reconciling the repo migration files with reality is a separate cleanup.